### PR TITLE
Fixes z C:\

### DIFF
--- a/zoxide.lua
+++ b/zoxide.lua
@@ -45,7 +45,7 @@ end
 
 -- Add directory to the database.
 local function __zoxide_add(dir)
-  os.execute('zoxide add -- "' .. dir .. '"')
+  os.execute('zoxide add -- "' .. dir:gsub('^(.-)\\*$', '%1') .. '"')
 end
 
 -- =============================================================================


### PR DESCRIPTION
The trailing backslash causes issues, so now it is excluded.