### PR TITLE
Configurable Hook (oh-my-posh compatibility)

### DIFF
--- a/zoxide.lua
+++ b/zoxide.lua
@@ -6,6 +6,8 @@
 settings.add('zoxide.cmd', 'z', 'Changes the prefix of the aliases')
 settings.add('zoxide.hook', { 'pwd', 'prompt', 'none' }, 'Changes when directory scores are incremented')
 settings.add('zoxide.no_aliases', false, "Don't define aliases")
+settings.add('zoxide.usepromptfilter', false, "Use clink promptfilter to hook even if onbeginedit is supported")
+settings.add('zoxide.promptfilter_prio', -50, "Changes the priority of the promptfilter hook (only if usepromptfilter is true)")
 
 -- =============================================================================
 --
@@ -52,11 +54,14 @@ end
 --
 -- Hook configuration for zoxide.
 --
+local __usepromptfilter = settings.get 'zoxide.usepromptfilter'
+
+if not clink.onbeginedit then
+  __usepromptfilter = true
+end
 
 local __zoxide_oldpwd
-local __zoxide_prompt = clink.promptfilter()
-
-function __zoxide_prompt:filter()
+function __zoxide_hook()
   local zoxide_hook = settings.get 'zoxide.hook'
 
   if zoxide_hook == 'none' then
@@ -73,6 +78,17 @@ function __zoxide_prompt:filter()
     end
     __zoxide_oldpwd = cwd
   end
+end
+
+if __usepromptfilter then
+  local __promptfilter_prio = settings.get 'zoxide.promptfilter_prio'
+  local __zoxide_prompt = clink.promptfilter(__promptfilter_prio)
+
+  function __zoxide_prompt:filter()
+    __zoxide_hook()
+  end
+else
+  clink.onbeginedit(__zoxide_hook)
 end
 
 -- =============================================================================


### PR DESCRIPTION
Changes:

- Use onbeginedit if available or zoxide.usepromptfilter set to true
- If using promptfilter, use a priority of -50 per default
- If using promptfilter and zoxide.promptfilter_prio is set, use that value

See https://github.com/JanDeDobbeleer/oh-my-posh/issues/4632#issuecomment-1897927562 for more info from the current clink maintainer (@chrisant996) .

Resolves issue #6 