### PR TITLE
Fix directory check for folders with spaces

### DIFF
--- a/zoxide.lua
+++ b/zoxide.lua
@@ -104,7 +104,7 @@ local function __zoxide_z(keywords)
     local keyword = keywords[1]
     if keyword == '-' then
       return __zoxide_cd '-'
-    elseif os.isdir(keyword) then
+    elseif os.isdir(keyword:gsub('"', '')) then
       return __zoxide_cd(keyword)
     end
   end


### PR DESCRIPTION
# Issue:

I was not able to use zoxide in clink to navigate to a directory that contains a space, because usually words separated by spaces are keywords used for matching. 

## For example:

```
> cd "Test folder"
zoxide: no match found
```

# Solution
The os.isdir() check failed when the string contained double quotes, so they were instead treated as keywords that needed to be matched. Tested on separate Windows 10 and 11 machines. The previous example now navigates to the folder as expected with regular cd, and keyword matching multiple words is still ok.

