### PR TITLE
Get the home directory in same way as clink does

### DIFF
--- a/zoxide.lua
+++ b/zoxide.lua
@@ -99,7 +99,9 @@ end
 -- 'z' alias
 local function __zoxide_z(keywords)
   if #keywords == 0 then
-    return __zoxide_cd(os.getenv 'USERPROFILE')
+    -- NOTE: `os.getenv("HOME")` returns HOME or HOMEDRIVE+HOMEPATH
+    --       or USERPROFILE.
+    return __zoxide_cd(os.getenv('HOME'))
   elseif #keywords == 1 then
     local keyword = keywords[1]
     if keyword == '-' then


### PR DESCRIPTION
Get the home directory in the same way as clink by using `os.getenv("HOME")` which makes a home directory string from the environment variables HOME or HOMEDRIVE+HOMEPATH or USERPROFILE in that order. This is the way used in `tilde-expand`.

Strictly speaking, the behavior has changed, but since the home directory is determined in the same way as 'Clink', no users should have any problems, I believe.