### PR TITLE
give unquoted full path string  to os.isdir() (resolve #11 and #15)

### DIFF
--- a/zoxide.lua
+++ b/zoxide.lua
@@ -96,6 +96,15 @@ end
 -- Define aliases.
 --
 
+-- remove double quotes
+function unquote(s)
+  local unquoted = string.match(s, '^"(.*)"$')
+  if unquoted then
+    return unquoted
+  end
+  return s
+end
+
 -- 'z' alias
 local function __zoxide_z(keywords)
   if #keywords == 0 then
@@ -106,8 +115,11 @@ local function __zoxide_z(keywords)
     local keyword = keywords[1]
     if keyword == '-' then
       return __zoxide_cd '-'
-    elseif os.isdir(keyword) then
-      return __zoxide_cd(keyword)
+    else
+      local path = os.getfullpathname(unquote(keyword))
+      if path and os.isdir(path) then
+        return __zoxide_cd(path)
+      end
     end
   end
 


### PR DESCRIPTION
`os.isdir("..")` on `c:\temp` unexpectedly returns nil. This can be avoided by calling `os.isdir()` with the full path. This solves issue #15 Additionally, `os.getfullpathname()` expects its argument to be unquoted, so we must pass the unquoted value. This change also resolves issue #11. .