### PR TITLE
Fix bugs in dir change corner cases

### DIFF
--- a/zoxide.lua
+++ b/zoxide.lua
@@ -23,10 +23,10 @@ local function __zoxide_cd(dir)
   -- 'cd /d -' doesn't work for clink versions before v1.2.41 (https://github.com/chrisant996/clink/issues/191)
   -- lastest cmder release (v1.3.18) uses clink v1.1.45
   if dir == '-' and (clink.version_encoded or 0) < 10020042 then
-    return 'cd -'
+    return ' cd -'
   end
 
-  return 'cd /d ' .. dir
+  return ' cd /d ' .. dir
 end
 
 -- Run `zoxide query` and generate `cd` command from result

--- a/zoxide.lua
+++ b/zoxide.lua
@@ -96,6 +96,15 @@ end
 -- Define aliases.
 --
 
+-- remove double quotes
+function unquote(s)
+  local unquoted = string.match(s, '^"(.*)"$')
+  if unquoted then
+    return unquoted
+  end
+  return s
+end
+
 -- 'z' alias
 local function __zoxide_z(keywords)
   if #keywords == 0 then
@@ -106,8 +115,11 @@ local function __zoxide_z(keywords)
     local keyword = keywords[1]
     if keyword == '-' then
       return __zoxide_cd '-'
-    elseif os.isdir(keyword) then
-      return __zoxide_cd(keyword)
+    else
+      local path = os.getfullpathname(unquote(keyword))
+      if path and os.isdir(path) then
+        return __zoxide_cd(path)
+      end
     end
   end
 


### PR DESCRIPTION
Fix cd command:
Add space so doskey macros aren't expanded.
Resolves #5

Give unquoted full path string to os.isdir():
`os.isdir("..")` on `c:\temp` unexpectedly returns nil.
This can be avoided by calling `os.isdir()` with the full path. 
Resolves #15
Additionally, `os.getfullpathname()` expects its argument to be unquoted,
so we must pass the unquoted value. 
Resolves #11


